### PR TITLE
rename leading section to "Preface"

### DIFF
--- a/src/SUMMARY.md
+++ b/src/SUMMARY.md
@@ -2,7 +2,7 @@
 
 [The Nix Package Manager](./ch00-00-the-nix-package-manager.md)
 
-[Forward](./ch01-00-forward.md)
+[Preface](./ch01-00-preface.md)
 
 [Introduction](./ch02-00-introduction.md)
 

--- a/src/ch01-00-preface.md
+++ b/src/ch01-00-preface.md
@@ -1,4 +1,4 @@
-# Foreward
+# Preface
 
 My journey to learn nix was only possible by my extreme desire to master it.
 The path was anything but easy and predictable. And it is still a considerable


### PR DESCRIPTION
A foreword (not "foreward" or "forward", btw.) is written by someone other than the author(s) of the book, usually by someone with name recognition, to give the author(s) and the book credibility.

A frontmatter section by the author(s) that describes how the book came to be or what the motivation behind making it was is called "preface". This is what the content of `ch01-00-*.md` currently is.

Cf. [section **"Front matter"** in Wikipedia article "Book design"](https://en.wikipedia.org/wiki/Book_design#Front_matter)