### PR TITLE
Fix serve instruction in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,6 @@ It's recommended to use this resource as a precursor to [nix-pills](https://nixo
 
 Use `nix develop` to have `mdbook` on your shell.
 
-Run `mdbook server` to launch a local webserver hosting the contents
+Run `mdbook serve` to launch a local webserver hosting the contents
 
 Run `mdbook build` to build nix-book.


### PR DESCRIPTION
In mdbook v0.4.10, `mdbook server` doesn't work (subcommand not recognized), but `mdbook serve` does.